### PR TITLE
feat: add Games management UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { NavLink, Navigate, Route, Routes } from 'react-router-dom'
 import PlayersPage from './pages/PlayersPage'
+import GamesPage from './pages/GamesPage'
 
 function Nav() {
   return (
@@ -13,6 +14,14 @@ function Nav() {
       >
         Players
       </NavLink>
+      <NavLink
+        to="/games"
+        className={({ isActive }) =>
+          isActive ? 'text-primary font-medium' : 'text-muted-foreground hover:text-foreground'
+        }
+      >
+        Games
+      </NavLink>
     </nav>
   )
 }
@@ -25,6 +34,7 @@ export default function App() {
         <Routes>
           <Route path="/" element={<Navigate to="/players" replace />} />
           <Route path="/players" element={<PlayersPage />} />
+          <Route path="/games" element={<GamesPage />} />
         </Routes>
       </main>
     </div>

--- a/frontend/src/api/__tests__/games.test.ts
+++ b/frontend/src/api/__tests__/games.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getGames, createGame, updateGame, deleteGame } from '../games'
+import * as client from '../client'
+
+vi.mock('../client', () => ({ apiFetch: vi.fn() }))
+const apiFetch = vi.mocked(client.apiFetch)
+
+const mockGame = {
+  id: 1,
+  game_date: '2026-06-01',
+  opponent: 'Red Sox',
+  location: 'Fenway Park',
+  is_home: false,
+  status: 'scheduled' as const,
+  created_at: '2024-01-01T00:00:00',
+  updated_at: '2024-01-01T00:00:00',
+}
+
+beforeEach(() => apiFetch.mockReset())
+
+describe('getGames', () => {
+  it('calls GET /games/', async () => {
+    apiFetch.mockResolvedValue([mockGame])
+    const result = await getGames()
+    expect(apiFetch).toHaveBeenCalledWith('/games/')
+    expect(result).toEqual([mockGame])
+  })
+})
+
+describe('createGame', () => {
+  it('calls POST /games/ with JSON body', async () => {
+    apiFetch.mockResolvedValue(mockGame)
+    await createGame({ game_date: '2026-06-01', opponent: 'Red Sox' })
+    expect(apiFetch).toHaveBeenCalledWith('/games/', {
+      method: 'POST',
+      body: JSON.stringify({ game_date: '2026-06-01', opponent: 'Red Sox' }),
+    })
+  })
+})
+
+describe('updateGame', () => {
+  it('calls PATCH /games/:id with JSON body', async () => {
+    apiFetch.mockResolvedValue({ ...mockGame, status: 'completed' })
+    await updateGame(1, { status: 'completed' })
+    expect(apiFetch).toHaveBeenCalledWith('/games/1', {
+      method: 'PATCH',
+      body: JSON.stringify({ status: 'completed' }),
+    })
+  })
+})
+
+describe('deleteGame', () => {
+  it('calls DELETE /games/:id', async () => {
+    apiFetch.mockResolvedValue(undefined)
+    await deleteGame(1)
+    expect(apiFetch).toHaveBeenCalledWith('/games/1', { method: 'DELETE' })
+  })
+})

--- a/frontend/src/api/games.ts
+++ b/frontend/src/api/games.ts
@@ -1,0 +1,44 @@
+import { apiFetch } from './client'
+
+export interface Game {
+  id: number
+  game_date: string
+  opponent: string
+  location: string | null
+  is_home: boolean
+  status: 'scheduled' | 'completed' | 'cancelled'
+  created_at: string
+  updated_at: string
+}
+
+export interface GameCreate {
+  game_date: string
+  opponent: string
+  location?: string | null
+  is_home?: boolean
+  status?: 'scheduled' | 'completed' | 'cancelled'
+}
+
+export type GameUpdate = Partial<GameCreate>
+
+export function getGames(): Promise<Game[]> {
+  return apiFetch<Game[]>('/games/')
+}
+
+export function createGame(data: GameCreate): Promise<Game> {
+  return apiFetch<Game>('/games/', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
+}
+
+export function updateGame(id: number, data: GameUpdate): Promise<Game> {
+  return apiFetch<Game>(`/games/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  })
+}
+
+export function deleteGame(id: number): Promise<void> {
+  return apiFetch<void>(`/games/${id}`, { method: 'DELETE' })
+}

--- a/frontend/src/components/games/GameDialog.tsx
+++ b/frontend/src/components/games/GameDialog.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import type { Game, GameCreate } from '@/api/games'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  onSubmit: (data: GameCreate) => Promise<void>
+  game?: Game
+}
+
+interface FormState {
+  game_date: string
+  opponent: string
+  location: string
+  is_home: boolean
+  status: 'scheduled' | 'completed' | 'cancelled'
+}
+
+function toFormState(game?: Game): FormState {
+  return {
+    game_date: game?.game_date ?? '',
+    opponent: game?.opponent ?? '',
+    location: game?.location ?? '',
+    is_home: game?.is_home ?? true,
+    status: game?.status ?? 'scheduled',
+  }
+}
+
+export default function GameDialog({ open, onClose, onSubmit, game }: Props) {
+  const [form, setForm] = useState<FormState>(toFormState(game))
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (open) {
+      setForm(toFormState(game))
+      setError(null)
+    }
+  }, [open, game])
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) {
+    const { name, value } = e.target
+    setForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setSubmitting(true)
+    setError(null)
+    try {
+      await onSubmit({
+        game_date: form.game_date,
+        opponent: form.opponent.trim(),
+        location: form.location.trim() || null,
+        is_home: form.is_home,
+        status: form.status,
+      })
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const isEdit = !!game
+  const canSubmit = form.game_date.trim() !== '' && form.opponent.trim() !== ''
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? 'Edit Game' : 'Add Game'}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="game_date">Date *</Label>
+            <Input
+              id="game_date"
+              name="game_date"
+              type="date"
+              value={form.game_date}
+              onChange={handleChange}
+              required
+              autoFocus
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="opponent">Opponent *</Label>
+            <Input
+              id="opponent"
+              name="opponent"
+              value={form.opponent}
+              onChange={handleChange}
+              required
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="location">Location</Label>
+            <Input
+              id="location"
+              name="location"
+              value={form.location}
+              onChange={handleChange}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="is_home"
+              checked={form.is_home}
+              onCheckedChange={(checked) =>
+                setForm((prev) => ({ ...prev, is_home: checked === true }))
+              }
+            />
+            <Label htmlFor="is_home">Home game</Label>
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="status">Status</Label>
+            <select
+              id="status"
+              name="status"
+              value={form.status}
+              onChange={handleChange}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            >
+              <option value="scheduled">Scheduled</option>
+              <option value="completed">Completed</option>
+              <option value="cancelled">Cancelled</option>
+            </select>
+          </div>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting || !canSubmit}>
+              {submitting ? 'Saving…' : isEdit ? 'Save Changes' : 'Add Game'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/games/GameTable.tsx
+++ b/frontend/src/components/games/GameTable.tsx
@@ -1,0 +1,83 @@
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import type { Game } from '@/api/games'
+
+interface Props {
+  games: Game[]
+  onEdit: (game: Game) => void
+  onDelete: (game: Game) => void
+}
+
+function StatusBadge({ status }: { status: Game['status'] }) {
+  if (status === 'completed') {
+    return <Badge className="bg-green-100 text-green-800 hover:bg-green-100">Completed</Badge>
+  }
+  if (status === 'cancelled') {
+    return <Badge variant="secondary">Cancelled</Badge>
+  }
+  return <Badge variant="outline">Scheduled</Badge>
+}
+
+export default function GameTable({ games, onEdit, onDelete }: Props) {
+  if (games.length === 0) {
+    return (
+      <p className="text-center text-muted-foreground py-12">No games yet.</p>
+    )
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Date</TableHead>
+          <TableHead>Opponent</TableHead>
+          <TableHead>Location</TableHead>
+          <TableHead>Home/Away</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="text-right">Actions</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {games.map((game) => (
+          <TableRow key={game.id}>
+            <TableCell>
+              {new Date(game.game_date + 'T00:00:00').toLocaleDateString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+              })}
+            </TableCell>
+            <TableCell className="font-medium">{game.opponent}</TableCell>
+            <TableCell className="text-muted-foreground">{game.location ?? '—'}</TableCell>
+            <TableCell>
+              {game.is_home ? (
+                <Badge className="bg-blue-100 text-blue-800 hover:bg-blue-100">Home</Badge>
+              ) : (
+                <Badge variant="secondary">Away</Badge>
+              )}
+            </TableCell>
+            <TableCell>
+              <StatusBadge status={game.status} />
+            </TableCell>
+            <TableCell className="text-right space-x-2">
+              <Button size="sm" variant="outline" onClick={() => onEdit(game)}>
+                Edit
+              </Button>
+              <Button size="sm" variant="destructive" onClick={() => onDelete(game)}>
+                Delete
+              </Button>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}

--- a/frontend/src/components/games/__tests__/GameDialog.test.tsx
+++ b/frontend/src/components/games/__tests__/GameDialog.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import GameDialog from '../GameDialog'
+import type { Game } from '@/api/games'
+
+const game: Game = {
+  id: 1,
+  game_date: '2026-06-01',
+  opponent: 'Red Sox',
+  location: 'Fenway Park',
+  is_home: false,
+  status: 'scheduled',
+  created_at: '2024-01-01T00:00:00',
+  updated_at: '2024-01-01T00:00:00',
+}
+
+describe('GameDialog — add mode', () => {
+  it('renders "Add Game" title when no game prop', () => {
+    render(<GameDialog open onClose={vi.fn()} onSubmit={vi.fn()} />)
+    expect(screen.getByRole('heading', { name: 'Add Game' })).toBeInTheDocument()
+  })
+
+  it('submit button is disabled when date or opponent is empty', () => {
+    render(<GameDialog open onClose={vi.fn()} onSubmit={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /add game/i })).toBeDisabled()
+  })
+
+  it('calls onSubmit and then onClose on success', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const onClose = vi.fn()
+    render(<GameDialog open onClose={onClose} onSubmit={onSubmit} />)
+
+    await userEvent.type(screen.getByLabelText(/opponent/i), 'Cubs')
+    await userEvent.type(screen.getByLabelText(/date/i), '2026-08-01')
+    await userEvent.click(screen.getByRole('button', { name: /add game/i }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ opponent: 'Cubs' }))
+    })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('shows error message when onSubmit rejects', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error('Server error'))
+    render(<GameDialog open onClose={vi.fn()} onSubmit={onSubmit} />)
+
+    await userEvent.type(screen.getByLabelText(/opponent/i), 'Cubs')
+    await userEvent.type(screen.getByLabelText(/date/i), '2026-08-01')
+    await userEvent.click(screen.getByRole('button', { name: /add game/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Server error')).toBeInTheDocument()
+    })
+  })
+
+  it('submit button shows "Saving…" and is disabled during submission', async () => {
+    let resolve!: () => void
+    const onSubmit = vi.fn().mockReturnValue(new Promise<void>((r) => { resolve = r }))
+    render(<GameDialog open onClose={vi.fn()} onSubmit={onSubmit} />)
+
+    await userEvent.type(screen.getByLabelText(/opponent/i), 'Cubs')
+    await userEvent.type(screen.getByLabelText(/date/i), '2026-08-01')
+    await userEvent.click(screen.getByRole('button', { name: /add game/i }))
+
+    expect(screen.getByRole('button', { name: /saving/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled()
+    resolve()
+  })
+})
+
+describe('GameDialog — null coercion', () => {
+  it('empty location becomes null on submit', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(<GameDialog open onClose={vi.fn()} onSubmit={onSubmit} />)
+    await userEvent.type(screen.getByLabelText(/opponent/i), 'Cubs')
+    await userEvent.type(screen.getByLabelText(/date/i), '2026-08-01')
+    await userEvent.click(screen.getByRole('button', { name: /add game/i }))
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ location: null }))
+    })
+  })
+
+  it('is_home defaults to true and can be unchecked', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(<GameDialog open onClose={vi.fn()} onSubmit={onSubmit} />)
+    const checkbox = screen.getByRole('checkbox', { name: /home game/i })
+    expect(checkbox).toBeChecked()
+    await userEvent.click(checkbox)
+    expect(checkbox).not.toBeChecked()
+    await userEvent.type(screen.getByLabelText(/opponent/i), 'Cubs')
+    await userEvent.type(screen.getByLabelText(/date/i), '2026-08-01')
+    await userEvent.click(screen.getByRole('button', { name: /add game/i }))
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ is_home: false }))
+    })
+  })
+})
+
+describe('GameDialog — edit mode', () => {
+  it('renders "Edit Game" title when game prop is provided', () => {
+    render(<GameDialog open onClose={vi.fn()} onSubmit={vi.fn()} game={game} />)
+    expect(screen.getByRole('heading', { name: 'Edit Game' })).toBeInTheDocument()
+  })
+
+  it('pre-fills the form with the game data', () => {
+    render(<GameDialog open onClose={vi.fn()} onSubmit={vi.fn()} game={game} />)
+    expect(screen.getByDisplayValue('Red Sox')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('2026-06-01')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Fenway Park')).toBeInTheDocument()
+  })
+
+  it('submit button shows "Save Changes" in edit mode', () => {
+    render(<GameDialog open onClose={vi.fn()} onSubmit={vi.fn()} game={game} />)
+    expect(screen.getByRole('button', { name: /save changes/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/games/__tests__/GameTable.test.tsx
+++ b/frontend/src/components/games/__tests__/GameTable.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import GameTable from '../GameTable'
+import type { Game } from '@/api/games'
+
+const game1: Game = {
+  id: 1,
+  game_date: '2026-06-01',
+  opponent: 'Red Sox',
+  location: 'Fenway Park',
+  is_home: false,
+  status: 'scheduled',
+  created_at: '2024-01-01T00:00:00',
+  updated_at: '2024-01-01T00:00:00',
+}
+
+const game2: Game = {
+  id: 2,
+  game_date: '2026-07-04',
+  opponent: 'Yankees',
+  location: null,
+  is_home: true,
+  status: 'completed',
+  created_at: '2024-01-01T00:00:00',
+  updated_at: '2024-01-01T00:00:00',
+}
+
+describe('GameTable', () => {
+  it('shows empty state message when no games', () => {
+    render(<GameTable games={[]} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    expect(screen.getByText(/no games yet/i)).toBeInTheDocument()
+  })
+
+  it('renders a row for each game', () => {
+    render(<GameTable games={[game1, game2]} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    expect(screen.getByText('Red Sox')).toBeInTheDocument()
+    expect(screen.getByText('Yankees')).toBeInTheDocument()
+  })
+
+  it('shows — when location is null', () => {
+    render(<GameTable games={[game2]} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  it('renders correct status badge text for all statuses', () => {
+    const cancelled: Game = { ...game1, id: 3, status: 'cancelled' }
+    render(<GameTable games={[game1, game2, cancelled]} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    expect(screen.getByText('Scheduled')).toBeInTheDocument()
+    expect(screen.getByText('Completed')).toBeInTheDocument()
+    expect(screen.getByText('Cancelled')).toBeInTheDocument()
+  })
+
+  it('renders Home badge for home games and Away for away games', () => {
+    render(<GameTable games={[game1, game2]} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    expect(screen.getByText('Away')).toBeInTheDocument()
+    expect(screen.getByText('Home')).toBeInTheDocument()
+  })
+
+  it('calls onEdit with the correct game when Edit is clicked', async () => {
+    const onEdit = vi.fn()
+    render(<GameTable games={[game1]} onEdit={onEdit} onDelete={vi.fn()} />)
+    await userEvent.click(screen.getByRole('button', { name: /edit/i }))
+    expect(onEdit).toHaveBeenCalledWith(game1)
+  })
+
+  it('calls onDelete with the correct game when Delete is clicked', async () => {
+    const onDelete = vi.fn()
+    render(<GameTable games={[game1]} onEdit={vi.fn()} onDelete={onDelete} />)
+    await userEvent.click(screen.getByRole('button', { name: /delete/i }))
+    expect(onDelete).toHaveBeenCalledWith(game1)
+  })
+})

--- a/frontend/src/pages/GamesPage.tsx
+++ b/frontend/src/pages/GamesPage.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import GameTable from '@/components/games/GameTable'
+import GameDialog from '@/components/games/GameDialog'
+import {
+  getGames,
+  createGame,
+  updateGame,
+  deleteGame,
+  type Game,
+  type GameCreate,
+} from '@/api/games'
+
+export default function GamesPage() {
+  const [games, setGames] = useState<Game[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editingGame, setEditingGame] = useState<Game | undefined>()
+
+  async function load() {
+    setLoading(true)
+    setError(null)
+    try {
+      setGames(await getGames())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load games')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void load()
+  }, [])
+
+  function openAdd() {
+    setEditingGame(undefined)
+    setDialogOpen(true)
+  }
+
+  function openEdit(game: Game) {
+    setEditingGame(game)
+    setDialogOpen(true)
+  }
+
+  async function handleSubmit(data: GameCreate) {
+    if (editingGame) {
+      await updateGame(editingGame.id, data)
+    } else {
+      await createGame(data)
+    }
+    await load()
+  }
+
+  async function handleDelete(game: Game) {
+    if (!confirm(`Delete game vs ${game.opponent}?`)) return
+    await deleteGame(game.id)
+    await load()
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Games</h1>
+        <Button onClick={openAdd}>Add Game</Button>
+      </div>
+
+      {loading && <p className="text-muted-foreground">Loading…</p>}
+      {error && <p className="text-destructive">{error}</p>}
+      {!loading && !error && (
+        <GameTable
+          games={games}
+          onEdit={openEdit}
+          onDelete={(g) => void handleDelete(g)}
+        />
+      )}
+
+      <GameDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        onSubmit={handleSubmit}
+        game={editingGame}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/__tests__/GamesPage.test.tsx
+++ b/frontend/src/pages/__tests__/GamesPage.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import GamesPage from '../GamesPage'
+import type { Game } from '@/api/games'
+
+vi.mock('@/api/games', () => ({
+  getGames: vi.fn(),
+  createGame: vi.fn(),
+  updateGame: vi.fn(),
+  deleteGame: vi.fn(),
+}))
+
+import { getGames, createGame, updateGame, deleteGame } from '@/api/games'
+
+const game1: Game = {
+  id: 1,
+  game_date: '2026-06-01',
+  opponent: 'Red Sox',
+  location: 'Fenway Park',
+  is_home: false,
+  status: 'scheduled',
+  created_at: '2024-01-01T00:00:00',
+  updated_at: '2024-01-01T00:00:00',
+}
+
+const game2: Game = {
+  id: 2,
+  game_date: '2026-07-04',
+  opponent: 'Yankees',
+  location: null,
+  is_home: true,
+  status: 'completed',
+  created_at: '2024-01-01T00:00:00',
+  updated_at: '2024-01-01T00:00:00',
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.mocked(getGames).mockResolvedValue([game1, game2])
+})
+
+describe('GamesPage', () => {
+  it('shows loading state on initial mount', () => {
+    vi.mocked(getGames).mockReturnValue(new Promise(() => {}))
+    render(<GamesPage />)
+    expect(screen.getByText(/loading/i)).toBeInTheDocument()
+  })
+
+  it('renders game rows after data loads', async () => {
+    render(<GamesPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Red Sox')).toBeInTheDocument()
+      expect(screen.getByText('Yankees')).toBeInTheDocument()
+    })
+  })
+
+  it('"Add Game" button opens the dialog', async () => {
+    render(<GamesPage />)
+    await waitFor(() => screen.getByText('Red Sox'))
+    await userEvent.click(screen.getByRole('button', { name: /add game/i }))
+    expect(screen.getByRole('heading', { name: 'Add Game' })).toBeInTheDocument()
+  })
+
+  it('Edit button opens dialog pre-filled with the game', async () => {
+    render(<GamesPage />)
+    await waitFor(() => screen.getByText('Red Sox'))
+    const editButtons = screen.getAllByRole('button', { name: /edit/i })
+    await userEvent.click(editButtons[0])
+    expect(screen.getByRole('heading', { name: 'Edit Game' })).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Red Sox')).toBeInTheDocument()
+  })
+
+  it('Delete button calls deleteGame and reloads', async () => {
+    vi.mocked(deleteGame).mockResolvedValue(undefined)
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    render(<GamesPage />)
+    await waitFor(() => screen.getByText('Red Sox'))
+    const deleteButtons = screen.getAllByRole('button', { name: /delete/i })
+    await userEvent.click(deleteButtons[0])
+    await waitFor(() => {
+      expect(deleteGame).toHaveBeenCalledWith(game1.id)
+    })
+  })
+
+  it('cancel confirm does not call deleteGame', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+    render(<GamesPage />)
+    await waitFor(() => screen.getByText('Red Sox'))
+    const deleteButtons = screen.getAllByRole('button', { name: /delete/i })
+    await userEvent.click(deleteButtons[0])
+    expect(deleteGame).not.toHaveBeenCalled()
+  })
+
+  it('submit in add mode calls createGame', async () => {
+    vi.mocked(createGame).mockResolvedValue({ ...game1, id: 3, opponent: 'Cubs' })
+    render(<GamesPage />)
+    await waitFor(() => screen.getByText('Red Sox'))
+    await userEvent.click(screen.getByRole('button', { name: /add game/i }))
+    await userEvent.type(screen.getByLabelText(/opponent/i), 'Cubs')
+    await userEvent.type(screen.getByLabelText(/date/i), '2026-08-01')
+    await userEvent.click(screen.getByRole('button', { name: /add game/i }))
+    await waitFor(() => {
+      expect(createGame).toHaveBeenCalledWith(expect.objectContaining({ opponent: 'Cubs' }))
+      expect(updateGame).not.toHaveBeenCalled()
+    })
+  })
+
+  it('submit in edit mode calls updateGame', async () => {
+    vi.mocked(updateGame).mockResolvedValue({ ...game1, opponent: 'Red Sox Updated' })
+    render(<GamesPage />)
+    await waitFor(() => screen.getByText('Red Sox'))
+    const editButtons = screen.getAllByRole('button', { name: /edit/i })
+    await userEvent.click(editButtons[0])
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }))
+    await waitFor(() => {
+      expect(updateGame).toHaveBeenCalledWith(game1.id, expect.any(Object))
+      expect(createGame).not.toHaveBeenCalled()
+    })
+  })
+
+  it('getGames is refetched after successful submit', async () => {
+    vi.mocked(createGame).mockResolvedValue({ ...game1, id: 3, opponent: 'Cubs' })
+    render(<GamesPage />)
+    await waitFor(() => screen.getByText('Red Sox'))
+    expect(getGames).toHaveBeenCalledTimes(1)
+    await userEvent.click(screen.getByRole('button', { name: /add game/i }))
+    await userEvent.type(screen.getByLabelText(/opponent/i), 'Cubs')
+    await userEvent.type(screen.getByLabelText(/date/i), '2026-08-01')
+    await userEvent.click(screen.getByRole('button', { name: /add game/i }))
+    await waitFor(() => {
+      expect(getGames).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('shows error message when getGames rejects', async () => {
+    vi.mocked(getGames).mockRejectedValue(new Error('Network error'))
+    render(<GamesPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error in dialog when createGame rejects', async () => {
+    vi.mocked(createGame).mockRejectedValue(new Error('Server error'))
+    render(<GamesPage />)
+    await waitFor(() => screen.getByText('Red Sox'))
+    await userEvent.click(screen.getByRole('button', { name: /add game/i }))
+    await userEvent.type(screen.getByLabelText(/opponent/i), 'Cubs')
+    await userEvent.type(screen.getByLabelText(/date/i), '2026-08-01')
+    await userEvent.click(screen.getByRole('button', { name: /add game/i }))
+    await waitFor(() => {
+      expect(screen.getByText('Server error')).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
Closes #15

## Summary

- Adds full Games CRUD frontend following the identical pattern as the Players feature
- New nav link and `/games` route wired into `App.tsx`
- 68 tests total (61 → 68), all passing; type check and build clean

## Files changed

| File | Change |
|------|--------|
| `src/api/games.ts` | New — typed API client |
| `src/api/__tests__/games.test.ts` | New — API client tests |
| `src/components/games/GameTable.tsx` | New — table with date, opponent, location, home/away badge, status badge |
| `src/components/games/GameDialog.tsx` | New — add/edit dialog |
| `src/components/games/__tests__/GameTable.test.tsx` | New — 7 table tests |
| `src/components/games/__tests__/GameDialog.test.tsx` | New — 10 dialog tests |
| `src/pages/GamesPage.tsx` | New — page component |
| `src/pages/__tests__/GamesPage.test.tsx` | New — 11 page tests |
| `src/App.tsx` | Add Games nav link + `/games` route |

## Test plan

- [x] `npm run test` — all 68 tests pass
- [x] `npm run build` — type check and build succeed
- [x] `npm run lint` — no new errors
- [x] Manual: navigate to `/games`, add/edit/delete a game

🤖 Generated with [Claude Code](https://claude.com/claude-code)