### PR TITLE
feat: game detail page with player availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,6 @@ backend/
 └── pyproject.toml       # Python dependencies and project config
 ```
 
-### Models vs Schemas — what's the difference?
-
-- **Models** (`app/models/`) define the shape of the data *in the database*. Each model maps to a table. For example, `Player` maps to the `players` table.
-- **Schemas** (`app/schemas/`) define the shape of the data *in the API*. They control what fields are required when creating something, what's optional when updating, and what gets returned in a response.
-
-They're kept separate because you often don't want to expose every database field in the API (e.g. internal IDs, timestamps), and you may want different fields when creating vs updating a record.
-
 ### Database tables
 
 | Table | What it stores |
@@ -121,21 +114,11 @@ The frontend is a single-page app (SPA) — the browser loads it once and then n
 ```
 frontend/
 ├── src/
-│   ├── main.tsx          # Entry point — wraps the app in BrowserRouter and mounts it
-│   ├── App.tsx           # Root — top nav and route definitions
-│   ├── api/
-│   │   ├── client.ts     # Base fetch wrapper (sets base URL, JSON headers, error handling)
-│   │   └── players.ts    # Typed functions for the players API
-│   ├── components/
-│   │   ├── players/      # Feature components for the Players page
-│   │   └── ui/           # Auto-generated shadcn/ui primitives (Button, Dialog, Table, etc.)
-│   ├── lib/
-│   │   └── utils.ts      # cn() — combines Tailwind classes safely
-│   └── pages/
-│       └── PlayersPage.tsx  # Players roster page
-├── index.html            # The single HTML file the browser loads
-├── vite.config.ts        # Build tool and Vitest config
-└── package.json          # Node dependencies and scripts
+│   ├── api/         # Typed API client functions
+│   ├── components/  # Feature components and shadcn/ui primitives
+│   ├── lib/         # Shared utilities
+│   └── pages/       # One file per route
+└── package.json
 ```
 
 ### Pages
@@ -143,6 +126,8 @@ frontend/
 | Route | Page | What it shows |
 |---|---|---|
 | `/players` | PlayersPage | Full roster — add, edit, delete players |
+| `/games` | GamesPage | Scheduled games — add, edit, delete games |
+| `/games/:id` | GameDetailPage | Game detail — metadata and per-player availability |
 
 ### Running the frontend locally
 
@@ -165,7 +150,7 @@ cd frontend
 npm run test
 ```
 
-Tests use [Vitest](https://vitest.dev/) and [React Testing Library](https://testing-library.com/). They cover the API client, players API module, and the PlayerTable and PlayerDialog components.
+Tests use [Vitest](https://vitest.dev/) and [React Testing Library](https://testing-library.com/). They cover the API clients, page components, and UI components.
 
 ---
 
@@ -176,19 +161,3 @@ Two automated workflows run on every push and pull request:
 - **Backend** (`.github/workflows/backend.yml`) — runs on changes to `backend/`. Checks linting (ruff), formatting (black), all tests (pytest), and verifies no database migrations are missing.
 - **Frontend** (`.github/workflows/frontend.yml`) — runs on changes to `frontend/`. Checks linting (eslint) and runs a full TypeScript type-check and build.
 
----
-
-## Glossary
-
-A few terms that come up a lot if you're newer to web dev:
-
-| Term | What it means here |
-|---|---|
-| **API** | The set of URLs the backend exposes. The frontend calls these to read/write data. |
-| **REST** | A convention for structuring API URLs and HTTP methods (GET = read, POST = create, PATCH = update, DELETE = delete). |
-| **Endpoint** | One specific URL in the API, e.g. `POST /players`. |
-| **Schema** | A description of the expected shape of data — which fields exist, what types they are. |
-| **Migration** | A script that updates the database structure (e.g. adds a new column) in a tracked, reversible way. |
-| **ORM** | "Object-Relational Mapper" — SQLAlchemy lets you work with database rows as Python objects instead of writing raw SQL. |
-| **SPA** | "Single-Page App" — the browser loads one HTML file and React handles all navigation client-side. |
-| **Vite** | The build tool for the frontend. In dev mode it serves files instantly with hot reload; for production it bundles everything into optimised static files. |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { NavLink, Navigate, Route, Routes } from 'react-router-dom'
 import PlayersPage from './pages/PlayersPage'
 import GamesPage from './pages/GamesPage'
+import GameDetailPage from './pages/GameDetailPage'
 
 function Nav() {
   return (
@@ -35,6 +36,7 @@ export default function App() {
           <Route path="/" element={<Navigate to="/players" replace />} />
           <Route path="/players" element={<PlayersPage />} />
           <Route path="/games" element={<GamesPage />} />
+          <Route path="/games/:id" element={<GameDetailPage />} />
         </Routes>
       </main>
     </div>

--- a/frontend/src/api/__tests__/availability.test.ts
+++ b/frontend/src/api/__tests__/availability.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getAvailability, createAvailability, updateAvailability } from '../availability'
+import * as client from '../client'
+
+vi.mock('../client', () => ({ apiFetch: vi.fn() }))
+const apiFetch = vi.mocked(client.apiFetch)
+
+const mockAvailability = {
+  id: 5,
+  game_id: 1,
+  player_id: 10,
+  is_available: true,
+  created_at: '2024-01-01T00:00:00',
+  updated_at: '2024-01-01T00:00:00',
+}
+
+beforeEach(() => apiFetch.mockReset())
+
+describe('getAvailability', () => {
+  it('calls GET /games/1/availability/', async () => {
+    apiFetch.mockResolvedValue([mockAvailability])
+    const result = await getAvailability(1)
+    expect(apiFetch).toHaveBeenCalledWith('/games/1/availability/')
+    expect(result).toEqual([mockAvailability])
+  })
+})
+
+describe('createAvailability', () => {
+  it('calls POST /games/1/availability/ with player_id and is_available', async () => {
+    apiFetch.mockResolvedValue(mockAvailability)
+    await createAvailability(1, 10, true)
+    expect(apiFetch).toHaveBeenCalledWith('/games/1/availability/', {
+      method: 'POST',
+      body: JSON.stringify({ player_id: 10, is_available: true }),
+    })
+  })
+})
+
+describe('updateAvailability', () => {
+  it('calls PATCH /games/1/availability/5 with is_available', async () => {
+    apiFetch.mockResolvedValue({ ...mockAvailability, is_available: false })
+    await updateAvailability(1, 5, false)
+    expect(apiFetch).toHaveBeenCalledWith('/games/1/availability/5', {
+      method: 'PATCH',
+      body: JSON.stringify({ is_available: false }),
+    })
+  })
+})

--- a/frontend/src/api/availability.ts
+++ b/frontend/src/api/availability.ts
@@ -1,0 +1,36 @@
+import { apiFetch } from './client'
+
+export interface GameAvailability {
+  id: number
+  game_id: number
+  player_id: number
+  is_available: boolean
+  created_at: string
+  updated_at: string
+}
+
+export function getAvailability(gameId: number): Promise<GameAvailability[]> {
+  return apiFetch<GameAvailability[]>(`/games/${gameId}/availability/`)
+}
+
+export function createAvailability(
+  gameId: number,
+  playerId: number,
+  isAvailable: boolean,
+): Promise<GameAvailability> {
+  return apiFetch<GameAvailability>(`/games/${gameId}/availability/`, {
+    method: 'POST',
+    body: JSON.stringify({ player_id: playerId, is_available: isAvailable }),
+  })
+}
+
+export function updateAvailability(
+  gameId: number,
+  availabilityId: number,
+  isAvailable: boolean,
+): Promise<GameAvailability> {
+  return apiFetch<GameAvailability>(`/games/${gameId}/availability/${availabilityId}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ is_available: isAvailable }),
+  })
+}

--- a/frontend/src/api/games.ts
+++ b/frontend/src/api/games.ts
@@ -25,6 +25,10 @@ export function getGames(): Promise<Game[]> {
   return apiFetch<Game[]>('/games/')
 }
 
+export function getGame(id: number): Promise<Game> {
+  return apiFetch<Game>(`/games/${id}`)
+}
+
 export function createGame(data: GameCreate): Promise<Game> {
   return apiFetch<Game>('/games/', {
     method: 'POST',

--- a/frontend/src/components/games/AvailabilityTable.tsx
+++ b/frontend/src/components/games/AvailabilityTable.tsx
@@ -1,0 +1,63 @@
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import type { Player } from '@/api/players'
+import type { GameAvailability } from '@/api/availability'
+
+interface Props {
+  players: Player[]
+  availability: GameAvailability[]
+  onToggle: (playerId: number, availabilityId: number | null, isAvailable: boolean) => void
+}
+
+export default function AvailabilityTable({ players, availability, onToggle }: Props) {
+  if (players.length === 0) {
+    return (
+      <p className="text-center text-muted-foreground py-12">No players found.</p>
+    )
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Player</TableHead>
+          <TableHead>Jersey</TableHead>
+          <TableHead>Preferred Position</TableHead>
+          <TableHead>Available</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {players.map((player) => {
+          const record = availability.find((a) => a.player_id === player.id)
+          const isAvailable = record?.is_available === true
+          return (
+            <TableRow key={player.id}>
+              <TableCell className="font-medium">{player.name}</TableCell>
+              <TableCell className="text-muted-foreground">
+                {player.jersey_number ?? '—'}
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                {player.preferred_position ?? '—'}
+              </TableCell>
+              <TableCell>
+                <Checkbox
+                  checked={isAvailable}
+                  onCheckedChange={(checked) =>
+                    onToggle(player.id, record?.id ?? null, checked === true)
+                  }
+                />
+              </TableCell>
+            </TableRow>
+          )
+        })}
+      </TableBody>
+    </Table>
+  )
+}

--- a/frontend/src/components/games/GameTable.tsx
+++ b/frontend/src/components/games/GameTable.tsx
@@ -12,6 +12,7 @@ import type { Game } from '@/api/games'
 
 interface Props {
   games: Game[]
+  onView: (game: Game) => void
   onEdit: (game: Game) => void
   onDelete: (game: Game) => void
 }
@@ -26,7 +27,7 @@ function StatusBadge({ status }: { status: Game['status'] }) {
   return <Badge variant="outline">Scheduled</Badge>
 }
 
-export default function GameTable({ games, onEdit, onDelete }: Props) {
+export default function GameTable({ games, onView, onEdit, onDelete }: Props) {
   if (games.length === 0) {
     return (
       <p className="text-center text-muted-foreground py-12">No games yet.</p>
@@ -68,6 +69,9 @@ export default function GameTable({ games, onEdit, onDelete }: Props) {
               <StatusBadge status={game.status} />
             </TableCell>
             <TableCell className="text-right space-x-2">
+              <Button size="sm" variant="outline" onClick={() => onView(game)}>
+                View
+              </Button>
               <Button size="sm" variant="outline" onClick={() => onEdit(game)}>
                 Edit
               </Button>

--- a/frontend/src/components/games/__tests__/AvailabilityTable.test.tsx
+++ b/frontend/src/components/games/__tests__/AvailabilityTable.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AvailabilityTable from '../AvailabilityTable'
+import type { Player } from '@/api/players'
+import type { GameAvailability } from '@/api/availability'
+
+const player1: Player = {
+  id: 10,
+  name: 'Alice',
+  jersey_number: '7',
+  preferred_position: 'SS',
+  capable_positions: ['SS', '2B'],
+  is_active: true,
+  created_at: '2024-01-01T00:00:00',
+  updated_at: '2024-01-01T00:00:00',
+}
+
+const player2: Player = {
+  id: 11,
+  name: 'Bob',
+  jersey_number: null,
+  preferred_position: null,
+  capable_positions: null,
+  is_active: true,
+  created_at: '2024-01-01T00:00:00',
+  updated_at: '2024-01-01T00:00:00',
+}
+
+const availableRecord: GameAvailability = {
+  id: 5,
+  game_id: 1,
+  player_id: 10,
+  is_available: true,
+  created_at: '2024-01-01T00:00:00',
+  updated_at: '2024-01-01T00:00:00',
+}
+
+const unavailableRecord: GameAvailability = {
+  id: 6,
+  game_id: 1,
+  player_id: 11,
+  is_available: false,
+  created_at: '2024-01-01T00:00:00',
+  updated_at: '2024-01-01T00:00:00',
+}
+
+describe('AvailabilityTable', () => {
+  it('shows empty state when players array is empty', () => {
+    render(<AvailabilityTable players={[]} availability={[]} onToggle={vi.fn()} />)
+    expect(screen.getByText(/no players found/i)).toBeInTheDocument()
+  })
+
+  it('renders a row per player', () => {
+    render(
+      <AvailabilityTable players={[player1, player2]} availability={[]} onToggle={vi.fn()} />,
+    )
+    expect(screen.getByText('Alice')).toBeInTheDocument()
+    expect(screen.getByText('Bob')).toBeInTheDocument()
+  })
+
+  it('checkbox is checked when availability record has is_available: true', () => {
+    render(
+      <AvailabilityTable
+        players={[player1]}
+        availability={[availableRecord]}
+        onToggle={vi.fn()}
+      />,
+    )
+    const checkbox = screen.getByRole('checkbox')
+    expect(checkbox).toBeChecked()
+  })
+
+  it('checkbox is unchecked when no availability record exists', () => {
+    render(
+      <AvailabilityTable players={[player1]} availability={[]} onToggle={vi.fn()} />,
+    )
+    const checkbox = screen.getByRole('checkbox')
+    expect(checkbox).not.toBeChecked()
+  })
+
+  it('checkbox is unchecked when is_available is false', () => {
+    render(
+      <AvailabilityTable
+        players={[player2]}
+        availability={[unavailableRecord]}
+        onToggle={vi.fn()}
+      />,
+    )
+    const checkbox = screen.getByRole('checkbox')
+    expect(checkbox).not.toBeChecked()
+  })
+
+  it('calls onToggle with (playerId, null, true) when no record exists and checkbox checked', async () => {
+    const onToggle = vi.fn()
+    render(
+      <AvailabilityTable players={[player1]} availability={[]} onToggle={onToggle} />,
+    )
+    await userEvent.click(screen.getByRole('checkbox'))
+    expect(onToggle).toHaveBeenCalledWith(player1.id, null, true)
+  })
+
+  it('calls onToggle with (playerId, recordId, false) when record exists and checkbox unchecked', async () => {
+    const onToggle = vi.fn()
+    render(
+      <AvailabilityTable
+        players={[player1]}
+        availability={[availableRecord]}
+        onToggle={onToggle}
+      />,
+    )
+    await userEvent.click(screen.getByRole('checkbox'))
+    expect(onToggle).toHaveBeenCalledWith(player1.id, availableRecord.id, false)
+  })
+})

--- a/frontend/src/components/games/__tests__/GameTable.test.tsx
+++ b/frontend/src/components/games/__tests__/GameTable.test.tsx
@@ -28,45 +28,52 @@ const game2: Game = {
 
 describe('GameTable', () => {
   it('shows empty state message when no games', () => {
-    render(<GameTable games={[]} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    render(<GameTable games={[]} onView={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />)
     expect(screen.getByText(/no games yet/i)).toBeInTheDocument()
   })
 
   it('renders a row for each game', () => {
-    render(<GameTable games={[game1, game2]} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    render(<GameTable games={[game1, game2]} onView={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />)
     expect(screen.getByText('Red Sox')).toBeInTheDocument()
     expect(screen.getByText('Yankees')).toBeInTheDocument()
   })
 
   it('shows — when location is null', () => {
-    render(<GameTable games={[game2]} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    render(<GameTable games={[game2]} onView={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />)
     expect(screen.getByText('—')).toBeInTheDocument()
   })
 
   it('renders correct status badge text for all statuses', () => {
     const cancelled: Game = { ...game1, id: 3, status: 'cancelled' }
-    render(<GameTable games={[game1, game2, cancelled]} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    render(<GameTable games={[game1, game2, cancelled]} onView={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />)
     expect(screen.getByText('Scheduled')).toBeInTheDocument()
     expect(screen.getByText('Completed')).toBeInTheDocument()
     expect(screen.getByText('Cancelled')).toBeInTheDocument()
   })
 
   it('renders Home badge for home games and Away for away games', () => {
-    render(<GameTable games={[game1, game2]} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    render(<GameTable games={[game1, game2]} onView={vi.fn()} onEdit={vi.fn()} onDelete={vi.fn()} />)
     expect(screen.getByText('Away')).toBeInTheDocument()
     expect(screen.getByText('Home')).toBeInTheDocument()
   })
 
+  it('calls onView with the correct game when View is clicked', async () => {
+    const onView = vi.fn()
+    render(<GameTable games={[game1]} onView={onView} onEdit={vi.fn()} onDelete={vi.fn()} />)
+    await userEvent.click(screen.getByRole('button', { name: /view/i }))
+    expect(onView).toHaveBeenCalledWith(game1)
+  })
+
   it('calls onEdit with the correct game when Edit is clicked', async () => {
     const onEdit = vi.fn()
-    render(<GameTable games={[game1]} onEdit={onEdit} onDelete={vi.fn()} />)
+    render(<GameTable games={[game1]} onView={vi.fn()} onEdit={onEdit} onDelete={vi.fn()} />)
     await userEvent.click(screen.getByRole('button', { name: /edit/i }))
     expect(onEdit).toHaveBeenCalledWith(game1)
   })
 
   it('calls onDelete with the correct game when Delete is clicked', async () => {
     const onDelete = vi.fn()
-    render(<GameTable games={[game1]} onEdit={vi.fn()} onDelete={onDelete} />)
+    render(<GameTable games={[game1]} onView={vi.fn()} onEdit={vi.fn()} onDelete={onDelete} />)
     await userEvent.click(screen.getByRole('button', { name: /delete/i }))
     expect(onDelete).toHaveBeenCalledWith(game1)
   })

--- a/frontend/src/pages/GameDetailPage.tsx
+++ b/frontend/src/pages/GameDetailPage.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import GameDialog from '@/components/games/GameDialog'
+import AvailabilityTable from '@/components/games/AvailabilityTable'
+import { getGame, updateGame, type Game, type GameCreate } from '@/api/games'
+import { getPlayers, type Player } from '@/api/players'
+import {
+  getAvailability,
+  createAvailability,
+  updateAvailability,
+  type GameAvailability,
+} from '@/api/availability'
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr + 'T00:00:00').toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+export default function GameDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const gameId = Number(id)
+
+  const [game, setGame] = useState<Game | null>(null)
+  const [players, setPlayers] = useState<Player[]>([])
+  const [availability, setAvailability] = useState<GameAvailability[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  async function load() {
+    setLoading(true)
+    setError(null)
+    try {
+      const [gameData, playersData, availabilityData] = await Promise.all([
+        getGame(gameId),
+        getPlayers(),
+        getAvailability(gameId),
+      ])
+      setGame(gameData)
+      setPlayers(playersData.filter((p) => p.is_active))
+      setAvailability(availabilityData)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load game')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void load()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gameId])
+
+  async function handleToggle(
+    playerId: number,
+    availabilityId: number | null,
+    isAvailable: boolean,
+  ) {
+    if (availabilityId === null) {
+      await createAvailability(gameId, playerId, isAvailable)
+    } else {
+      await updateAvailability(gameId, availabilityId, isAvailable)
+    }
+    await load()
+  }
+
+  async function handleEditSubmit(data: GameCreate) {
+    await updateGame(gameId, data)
+    await load()
+  }
+
+  if (loading) {
+    return <p className="text-muted-foreground">Loading…</p>
+  }
+
+  if (error) {
+    return <p className="text-destructive">{error}</p>
+  }
+
+  if (!game) return null
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <Button variant="ghost" onClick={() => navigate('/games')}>
+          ← Games
+        </Button>
+        <Button variant="outline" onClick={() => setDialogOpen(true)}>
+          Edit Game
+        </Button>
+      </div>
+
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold">vs {game.opponent}</h1>
+        <p className="text-muted-foreground">
+          {formatDate(game.game_date)} ·{' '}
+          {game.is_home ? (
+            <Badge className="bg-blue-100 text-blue-800 hover:bg-blue-100">Home</Badge>
+          ) : (
+            <Badge variant="secondary">Away</Badge>
+          )}{' '}
+          · {game.status.charAt(0).toUpperCase() + game.status.slice(1)}
+        </p>
+        {game.location && <p className="text-muted-foreground">{game.location}</p>}
+      </div>
+
+      <div className="space-y-2">
+        <h2 className="text-lg font-medium">Player Availability</h2>
+        <AvailabilityTable
+          players={players}
+          availability={availability}
+          onToggle={(playerId, availabilityId, isAvailable) =>
+            void handleToggle(playerId, availabilityId, isAvailable)
+          }
+        />
+      </div>
+
+      <GameDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        onSubmit={handleEditSubmit}
+        game={game}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/GamesPage.tsx
+++ b/frontend/src/pages/GamesPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import GameTable from '@/components/games/GameTable'
 import GameDialog from '@/components/games/GameDialog'
@@ -12,6 +13,7 @@ import {
 } from '@/api/games'
 
 export default function GamesPage() {
+  const navigate = useNavigate()
   const [games, setGames] = useState<Game[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -72,6 +74,7 @@ export default function GamesPage() {
       {!loading && !error && (
         <GameTable
           games={games}
+          onView={(g) => navigate(`/games/${g.id}`)}
           onEdit={openEdit}
           onDelete={(g) => void handleDelete(g)}
         />

--- a/frontend/src/pages/__tests__/GameDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/GameDetailPage.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import GameDetailPage from '../GameDetailPage'
+import type { Game } from '@/api/games'
+import type { Player } from '@/api/players'
+import type { GameAvailability } from '@/api/availability'
+
+vi.mock('@/api/games', () => ({
+  getGame: vi.fn(),
+  updateGame: vi.fn(),
+}))
+
+vi.mock('@/api/players', () => ({
+  getPlayers: vi.fn(),
+}))
+
+vi.mock('@/api/availability', () => ({
+  getAvailability: vi.fn(),
+  createAvailability: vi.fn(),
+  updateAvailability: vi.fn(),
+}))
+
+import { getGame, updateGame } from '@/api/games'
+import { getPlayers } from '@/api/players'
+import { getAvailability, createAvailability, updateAvailability } from '@/api/availability'
+
+const game: Game = {
+  id: 1,
+  game_date: '2026-06-01',
+  opponent: 'Red Sox',
+  location: 'Fenway Park',
+  is_home: false,
+  status: 'scheduled',
+  created_at: '2024-01-01T00:00:00',
+  updated_at: '2024-01-01T00:00:00',
+}
+
+const player: Player = {
+  id: 10,
+  name: 'Alice',
+  jersey_number: '7',
+  preferred_position: 'SS',
+  capable_positions: ['SS'],
+  is_active: true,
+  created_at: '2024-01-01T00:00:00',
+  updated_at: '2024-01-01T00:00:00',
+}
+
+const availabilityRecord: GameAvailability = {
+  id: 5,
+  game_id: 1,
+  player_id: 10,
+  is_available: true,
+  created_at: '2024-01-01T00:00:00',
+  updated_at: '2024-01-01T00:00:00',
+}
+
+function renderPage(gameId = '1') {
+  return render(
+    <MemoryRouter initialEntries={[`/games/${gameId}`]}>
+      <Routes>
+        <Route path="/games/:id" element={<GameDetailPage />} />
+        <Route path="/games" element={<div>Games List</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  vi.mocked(getGame).mockResolvedValue(game)
+  vi.mocked(getPlayers).mockResolvedValue([player])
+  vi.mocked(getAvailability).mockResolvedValue([])
+  vi.mocked(updateGame).mockResolvedValue(game)
+  vi.mocked(createAvailability).mockResolvedValue(availabilityRecord)
+  vi.mocked(updateAvailability).mockResolvedValue({ ...availabilityRecord, is_available: false })
+})
+
+describe('GameDetailPage', () => {
+  it('shows loading state on mount', () => {
+    vi.mocked(getGame).mockReturnValue(new Promise(() => {}))
+    renderPage()
+    expect(screen.getByText(/loading/i)).toBeInTheDocument()
+  })
+
+  it('renders game header after load', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText(/vs Red Sox/i)).toBeInTheDocument()
+      expect(screen.getByText(/Fenway Park/i)).toBeInTheDocument()
+    })
+  })
+
+  it('renders player rows in availability table', async () => {
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Alice')).toBeInTheDocument()
+    })
+  })
+
+  it('calls createAvailability when no prior record and checkbox checked', async () => {
+    vi.mocked(getAvailability).mockResolvedValue([])
+    renderPage()
+    await waitFor(() => screen.getByText('Alice'))
+    await userEvent.click(screen.getByRole('checkbox'))
+    await waitFor(() => {
+      expect(createAvailability).toHaveBeenCalledWith(1, player.id, true)
+    })
+  })
+
+  it('calls updateAvailability when prior record exists and checkbox toggled', async () => {
+    vi.mocked(getAvailability).mockResolvedValue([availabilityRecord])
+    renderPage()
+    await waitFor(() => screen.getByText('Alice'))
+    await userEvent.click(screen.getByRole('checkbox'))
+    await waitFor(() => {
+      expect(updateAvailability).toHaveBeenCalledWith(1, availabilityRecord.id, false)
+    })
+  })
+
+  it('refetches getAvailability after toggle', async () => {
+    renderPage()
+    await waitFor(() => screen.getByText('Alice'))
+    expect(getAvailability).toHaveBeenCalledTimes(1)
+    await userEvent.click(screen.getByRole('checkbox'))
+    await waitFor(() => {
+      expect(getAvailability).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('shows error message when getGame rejects', async () => {
+    vi.mocked(getGame).mockRejectedValue(new Error('Not found'))
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Not found')).toBeInTheDocument()
+    })
+  })
+
+  it('"Edit Game" button opens dialog pre-filled', async () => {
+    renderPage()
+    await waitFor(() => screen.getByText(/vs Red Sox/i))
+    await userEvent.click(screen.getByRole('button', { name: /edit game/i }))
+    expect(screen.getByRole('heading', { name: 'Edit Game' })).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Red Sox')).toBeInTheDocument()
+  })
+
+  it('submitting dialog calls updateGame then reloads', async () => {
+    renderPage()
+    await waitFor(() => screen.getByText(/vs Red Sox/i))
+    await userEvent.click(screen.getByRole('button', { name: /edit game/i }))
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }))
+    await waitFor(() => {
+      expect(updateGame).toHaveBeenCalledWith(1, expect.any(Object))
+      expect(getGame).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('"← Games" navigates back to /games', async () => {
+    renderPage()
+    await waitFor(() => screen.getByText(/vs Red Sox/i))
+    await userEvent.click(screen.getByRole('button', { name: /← games/i }))
+    expect(screen.getByText('Games List')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/__tests__/GamesPage.test.tsx
+++ b/frontend/src/pages/__tests__/GamesPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import userEvent from '@testing-library/user-event'
 import GamesPage from '../GamesPage'
 import type { Game } from '@/api/games'
@@ -43,12 +44,12 @@ beforeEach(() => {
 describe('GamesPage', () => {
   it('shows loading state on initial mount', () => {
     vi.mocked(getGames).mockReturnValue(new Promise(() => {}))
-    render(<GamesPage />)
+    render(<MemoryRouter><GamesPage /></MemoryRouter>)
     expect(screen.getByText(/loading/i)).toBeInTheDocument()
   })
 
   it('renders game rows after data loads', async () => {
-    render(<GamesPage />)
+    render(<MemoryRouter><GamesPage /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('Red Sox')).toBeInTheDocument()
       expect(screen.getByText('Yankees')).toBeInTheDocument()
@@ -56,14 +57,14 @@ describe('GamesPage', () => {
   })
 
   it('"Add Game" button opens the dialog', async () => {
-    render(<GamesPage />)
+    render(<MemoryRouter><GamesPage /></MemoryRouter>)
     await waitFor(() => screen.getByText('Red Sox'))
     await userEvent.click(screen.getByRole('button', { name: /add game/i }))
     expect(screen.getByRole('heading', { name: 'Add Game' })).toBeInTheDocument()
   })
 
   it('Edit button opens dialog pre-filled with the game', async () => {
-    render(<GamesPage />)
+    render(<MemoryRouter><GamesPage /></MemoryRouter>)
     await waitFor(() => screen.getByText('Red Sox'))
     const editButtons = screen.getAllByRole('button', { name: /edit/i })
     await userEvent.click(editButtons[0])
@@ -74,7 +75,7 @@ describe('GamesPage', () => {
   it('Delete button calls deleteGame and reloads', async () => {
     vi.mocked(deleteGame).mockResolvedValue(undefined)
     vi.spyOn(window, 'confirm').mockReturnValue(true)
-    render(<GamesPage />)
+    render(<MemoryRouter><GamesPage /></MemoryRouter>)
     await waitFor(() => screen.getByText('Red Sox'))
     const deleteButtons = screen.getAllByRole('button', { name: /delete/i })
     await userEvent.click(deleteButtons[0])
@@ -85,7 +86,7 @@ describe('GamesPage', () => {
 
   it('cancel confirm does not call deleteGame', async () => {
     vi.spyOn(window, 'confirm').mockReturnValue(false)
-    render(<GamesPage />)
+    render(<MemoryRouter><GamesPage /></MemoryRouter>)
     await waitFor(() => screen.getByText('Red Sox'))
     const deleteButtons = screen.getAllByRole('button', { name: /delete/i })
     await userEvent.click(deleteButtons[0])
@@ -94,7 +95,7 @@ describe('GamesPage', () => {
 
   it('submit in add mode calls createGame', async () => {
     vi.mocked(createGame).mockResolvedValue({ ...game1, id: 3, opponent: 'Cubs' })
-    render(<GamesPage />)
+    render(<MemoryRouter><GamesPage /></MemoryRouter>)
     await waitFor(() => screen.getByText('Red Sox'))
     await userEvent.click(screen.getByRole('button', { name: /add game/i }))
     await userEvent.type(screen.getByLabelText(/opponent/i), 'Cubs')
@@ -108,7 +109,7 @@ describe('GamesPage', () => {
 
   it('submit in edit mode calls updateGame', async () => {
     vi.mocked(updateGame).mockResolvedValue({ ...game1, opponent: 'Red Sox Updated' })
-    render(<GamesPage />)
+    render(<MemoryRouter><GamesPage /></MemoryRouter>)
     await waitFor(() => screen.getByText('Red Sox'))
     const editButtons = screen.getAllByRole('button', { name: /edit/i })
     await userEvent.click(editButtons[0])
@@ -121,7 +122,7 @@ describe('GamesPage', () => {
 
   it('getGames is refetched after successful submit', async () => {
     vi.mocked(createGame).mockResolvedValue({ ...game1, id: 3, opponent: 'Cubs' })
-    render(<GamesPage />)
+    render(<MemoryRouter><GamesPage /></MemoryRouter>)
     await waitFor(() => screen.getByText('Red Sox'))
     expect(getGames).toHaveBeenCalledTimes(1)
     await userEvent.click(screen.getByRole('button', { name: /add game/i }))
@@ -135,7 +136,7 @@ describe('GamesPage', () => {
 
   it('shows error message when getGames rejects', async () => {
     vi.mocked(getGames).mockRejectedValue(new Error('Network error'))
-    render(<GamesPage />)
+    render(<MemoryRouter><GamesPage /></MemoryRouter>)
     await waitFor(() => {
       expect(screen.getByText('Network error')).toBeInTheDocument()
     })
@@ -143,7 +144,7 @@ describe('GamesPage', () => {
 
   it('shows error in dialog when createGame rejects', async () => {
     vi.mocked(createGame).mockRejectedValue(new Error('Server error'))
-    render(<GamesPage />)
+    render(<MemoryRouter><GamesPage /></MemoryRouter>)
     await waitFor(() => screen.getByText('Red Sox'))
     await userEvent.click(screen.getByRole('button', { name: /add game/i }))
     await userEvent.type(screen.getByLabelText(/opponent/i), 'Cubs')
@@ -152,5 +153,20 @@ describe('GamesPage', () => {
     await waitFor(() => {
       expect(screen.getByText('Server error')).toBeInTheDocument()
     })
+  })
+
+  it('View button navigates to /games/:id', async () => {
+    render(
+      <MemoryRouter initialEntries={['/games']}>
+        <Routes>
+          <Route path="/games" element={<GamesPage />} />
+          <Route path="/games/:id" element={<div>Game Detail</div>} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    await waitFor(() => screen.getByText('Red Sox'))
+    const viewButtons = screen.getAllByRole('button', { name: /view/i })
+    await userEvent.click(viewButtons[0])
+    expect(screen.getByText('Game Detail')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Closes #17

## Summary

- Adds `/games/:id` detail page with game metadata and an availability table
- Checkbox per player — POST on first toggle, PATCH on subsequent changes
- **View** button added to the games list table
- New typed `availability.ts` API client
- `getGame(id)` added to `games.ts`
- README updated (removed Glossary and Models vs Schemas sections, updated frontend structure and pages table)

## Test plan

- [ ] 90 tests passing (`npm run test`)
- [ ] Lint and build clean (`npm run lint && npm run build`)
- [x] `/games` → click **View** → detail page loads with game header and player rows
- [x] Toggle a player available → checkbox stays checked on reload
- [x] Toggle unavailable → reflected on reload
- [x] Click **Edit Game** → dialog opens pre-filled → save → header updates
- [x] **← Games** → back to list

🤖 Generated with [Claude Code](https://claude.com/claude-code)