### PR TITLE
refactor: move abbreviateName into lib/utils

### DIFF
--- a/frontend/src/components/games/DiamondView.tsx
+++ b/frontend/src/components/games/DiamondView.tsx
@@ -1,15 +1,6 @@
 import type { LineupSlotRead } from '@/api/lineups'
 import type { Player } from '@/api/players'
 
-// eslint-disable-next-line react-refresh/only-export-components
-export function abbreviateName(name: string): string {
-  if (!name) return '?'
-  const parts = name.trim().split(/\s+/)
-  if (parts.length === 1) return parts[0]
-  const last = parts[parts.length - 1]
-  return `${parts[0][0]}. ${last}`
-}
-
 const POSITIONS = [
   { key: 'CF', left: '50%', top: '5%'  },
   { key: 'LF', left: '15%', top: '28%' },

--- a/frontend/src/components/games/__tests__/DiamondView.test.tsx
+++ b/frontend/src/components/games/__tests__/DiamondView.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import DiamondView, { abbreviateName } from '../DiamondView'
+import DiamondView from '../DiamondView'
+import { abbreviateName } from '@/lib/utils'
 import type { Player } from '@/api/players'
 import type { LineupSlotRead } from '@/api/lineups'
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,11 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function abbreviateName(name: string): string {
+  if (!name) return '?'
+  const parts = name.trim().split(/\s+/)
+  if (parts.length === 1) return parts[0]
+  const last = parts[parts.length - 1]
+  return `${parts[0][0]}. ${last}`
+}


### PR DESCRIPTION
## Summary
- Moves the `abbreviateName` helper out of `DiamondView.tsx` and into `src/lib/utils.ts` where general-purpose utilities live
- Removes the `// eslint-disable-next-line react-refresh/only-export-components` comment that was only needed because a non-component was exported from a component file
- Updates the test import in `DiamondView.test.tsx` to pull from `@/lib/utils`

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)