### PR TITLE
fix: global player name disambiguation in DiamondView

### DIFF
--- a/frontend/src/components/games/DiamondView.tsx
+++ b/frontend/src/components/games/DiamondView.tsx
@@ -62,8 +62,8 @@ function FieldSvg() {
   )
 }
 
-// Show first name only; fall back to "First Last" when two players at the
-// same position share the same first name.
+// Show first name only; fall back to "First Last" when any two available
+// players share the same first name (checked globally, not per-position).
 function getCardName(player: Player, peers: Player[]): string {
   const parts = player.name.trim().split(/\s+/)
   const first = parts[0]
@@ -92,7 +92,7 @@ export default function DiamondView({ availablePlayers, slots, onAssign, onUnass
               <span className="text-xs font-bold text-green-800">{pos.key}</span>
               <div className="flex flex-col gap-1">
                 {playersAtPos.map((player) => {
-                  const label = getCardName(player, playersAtPos)
+                  const label = getCardName(player, availablePlayers)
                   const assignedSlot = slots.find(
                     (s) => s.player_id === player.id && s.fielding_position === pos.key,
                   )

--- a/frontend/src/components/games/__tests__/DiamondView.test.tsx
+++ b/frontend/src/components/games/__tests__/DiamondView.test.tsx
@@ -135,6 +135,14 @@ describe('DiamondView', () => {
     expect(screen.getByRole('button', { name: 'Alice Smith' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Alice Jones' })).toBeInTheDocument()
   })
+
+  it('shows first+last name when two players share a first name at different positions', () => {
+    const aliceSS: Player = { ...alice, capable_positions: ['SS'] }
+    const aliceCF: Player = { ...alice, id: 99, name: 'Alice Jones', capable_positions: ['CF'] }
+    renderDiamond({ availablePlayers: [aliceSS, aliceCF], slots: [] })
+    expect(screen.getByRole('button', { name: 'Alice Smith' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Alice Jones' })).toBeInTheDocument()
+  })
 })
 
 describe('abbreviateName', () => {


### PR DESCRIPTION
## Summary
- `getCardName` previously checked for first-name collisions only among players at the **same position**, so two players named "Alex" at different positions would both appear as just "Alex"
- Fix: pass `availablePlayers` (all available players) instead of `playersAtPos` to the collision check
- Updates the comment to reflect the global scope
- Adds a test for the cross-position collision case

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)