### PR TITLE
feat: DH/Flex support in lineup builder

### DIFF
--- a/backend/alembic/versions/e2f3a4b5c6d7_add_is_flex_to_lineup_slots.py
+++ b/backend/alembic/versions/e2f3a4b5c6d7_add_is_flex_to_lineup_slots.py
@@ -1,0 +1,28 @@
+"""add is_flex to lineup_slots
+
+Revision ID: e2f3a4b5c6d7
+Revises: d1e2f3a4b5c6
+Create Date: 2026-03-25
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e2f3a4b5c6d7"
+down_revision: Union[str, None] = "d1e2f3a4b5c6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "lineup_slots",
+        sa.Column("is_flex", sa.Boolean(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("lineup_slots", "is_flex")

--- a/backend/app/models/lineup_slot.py
+++ b/backend/app/models/lineup_slot.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from sqlalchemy import ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy import Boolean, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .base import Base, TimestampMixin
@@ -21,6 +21,9 @@ class LineupSlot(Base, TimestampMixin):
     player_id: Mapped[int] = mapped_column(ForeignKey("players.id"), nullable=False)
     batting_order: Mapped[int] = mapped_column(Integer, nullable=False)
     fielding_position: Mapped[str] = mapped_column(String, nullable=False)
+    is_flex: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
+    )
 
     lineup: Mapped["Lineup"] = relationship("Lineup", back_populates="slots")
     player: Mapped["Player"] = relationship("Player", back_populates="lineup_slots")

--- a/backend/app/schemas/lineup_slot.py
+++ b/backend/app/schemas/lineup_slot.py
@@ -8,11 +8,13 @@ class LineupSlotCreate(BaseModel):
     player_id: int
     batting_order: int
     fielding_position: str
+    is_flex: bool = False
 
 
 class LineupSlotUpdate(BaseModel):
     batting_order: Optional[int] = None
     fielding_position: Optional[str] = None
+    is_flex: Optional[bool] = None
 
 
 class LineupReorder(BaseModel):
@@ -25,6 +27,7 @@ class LineupSlotRead(BaseModel):
     player_id: int
     batting_order: int
     fielding_position: str
+    is_flex: bool
     created_at: datetime
     updated_at: datetime
 

--- a/frontend/src/api/lineups.ts
+++ b/frontend/src/api/lineups.ts
@@ -15,6 +15,7 @@ export interface LineupSlotRead {
   player_id: number
   batting_order: number
   fielding_position: string
+  is_flex: boolean
   created_at: string
   updated_at: string
 }
@@ -27,11 +28,13 @@ export interface LineupSlotCreate {
   player_id: number
   batting_order: number
   fielding_position: string
+  is_flex?: boolean
 }
 
 export interface LineupSlotUpdate {
   batting_order?: number
   fielding_position?: string
+  is_flex?: boolean
 }
 
 export function getLineups(gameId: number): Promise<LineupRead[]> {

--- a/frontend/src/components/games/LineupOrder.tsx
+++ b/frontend/src/components/games/LineupOrder.tsx
@@ -22,6 +22,10 @@ interface Props {
   players: Player[]
   availablePlayers: Player[]
   onReorder?: (orderedSlotIds: number[]) => void
+  onSetFlex?: (slotId: number, isFlex: boolean) => void
+  onAssignDH?: (playerId: number) => void
+  onUnassignFlex?: (slotId: number) => void
+  busy?: boolean
 }
 
 interface RowProps {
@@ -29,9 +33,11 @@ interface RowProps {
   index: number
   name: string
   isOutOfPosition: boolean
+  onSetFlex?: (slotId: number, isFlex: boolean) => void
+  busy?: boolean
 }
 
-function SortableRow({ slot, index, name, isOutOfPosition }: RowProps) {
+function SortableRow({ slot, index, name, isOutOfPosition, onSetFlex, busy }: RowProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: slot.id })
   const style = {
@@ -39,6 +45,7 @@ function SortableRow({ slot, index, name, isOutOfPosition }: RowProps) {
     transition,
     opacity: isDragging ? 0.4 : 1,
   }
+  const isDH = slot.fielding_position === 'DH'
   return (
     <tr
       ref={setNodeRef}
@@ -48,24 +55,55 @@ function SortableRow({ slot, index, name, isOutOfPosition }: RowProps) {
       {...listeners}
       role="row"
     >
-      <td className="py-1">{index + 1}. {name}</td>
+      <td className="py-1 w-6 text-muted-foreground text-xs">{index + 1}.</td>
+      <td className="py-1">{name}</td>
       <td className={`py-1 pl-3 ${isOutOfPosition ? 'text-amber-600' : 'text-muted-foreground'}`}>
         {slot.fielding_position}
+      </td>
+      <td className="py-1 pl-2 text-right">
+        {!isDH && (
+          <button
+            aria-label={slot.is_flex ? 'Unmark Flex' : 'Mark as Flex'}
+            disabled={busy}
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => { e.stopPropagation(); onSetFlex?.(slot.id, !slot.is_flex) }}
+            className={`text-xs px-1.5 py-0.5 rounded border transition-colors disabled:opacity-30 ${
+              slot.is_flex
+                ? 'bg-blue-100 text-blue-700 border-blue-300 hover:bg-blue-200'
+                : 'text-muted-foreground border-muted hover:bg-muted'
+            }`}
+          >
+            F
+          </button>
+        )}
       </td>
     </tr>
   )
 }
 
-export default function LineupOrder({ slots, players, availablePlayers, onReorder }: Props) {
+export default function LineupOrder({
+  slots, players, availablePlayers,
+  onReorder, onSetFlex, onAssignDH, onUnassignFlex, busy = false,
+}: Props) {
   const sensors = useSensors(useSensor(PointerSensor))
-  const sorted = useMemo(
-    () => [...slots].sort((a, b) => a.batting_order - b.batting_order),
+
+  const flexSlot = useMemo(() => slots.find((s) => s.is_flex), [slots])
+  const dhSlot = useMemo(() => slots.find((s) => s.fielding_position === 'DH'), [slots])
+
+  // Regular batting order: all non-Flex slots (including DH), sorted by batting_order
+  const regularSorted = useMemo(
+    () => [...slots].filter((s) => !s.is_flex).sort((a, b) => a.batting_order - b.batting_order),
     [slots],
   )
+
   const benchPlayers = useMemo(
     () => availablePlayers.filter((p) => !slots.some((s) => s.player_id === p.id)),
     [availablePlayers, slots],
   )
+
+  const flexPlayer = flexSlot ? players.find((p) => p.id === flexSlot.player_id) : null
+
+  const showWarning = (flexSlot && !dhSlot) || (dhSlot && !flexSlot)
 
   if (slots.length === 0 && benchPlayers.length === 0) {
     return <p className="text-muted-foreground text-sm">Mark players available, then assign them from the diamond.</p>
@@ -74,10 +112,12 @@ export default function LineupOrder({ slots, players, availablePlayers, onReorde
   function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event
     if (!over || active.id === over.id) return
-    const oldIndex = sorted.findIndex((s) => s.id === active.id)
-    const newIndex = sorted.findIndex((s) => s.id === over.id)
-    const reordered = arrayMove(sorted, oldIndex, newIndex)
-    onReorder?.(reordered.map((s) => s.id))
+    const oldIndex = regularSorted.findIndex((s) => s.id === active.id)
+    const newIndex = regularSorted.findIndex((s) => s.id === over.id)
+    const reordered = arrayMove(regularSorted, oldIndex, newIndex)
+    // Flex slot always goes last so it gets the highest batting_order
+    const flexIds = flexSlot ? [flexSlot.id] : []
+    onReorder?.([...reordered.map((s) => s.id), ...flexIds])
   }
 
   return (
@@ -85,37 +125,89 @@ export default function LineupOrder({ slots, players, availablePlayers, onReorde
       {slots.length === 0 && (
         <p className="text-muted-foreground text-sm mb-3">Assign players from the diamond to build the batting order.</p>
       )}
-      {slots.length > 0 && (
+
+      {showWarning && (
+        <p className="text-xs text-amber-600 mb-2">
+          {flexSlot && !dhSlot
+            ? 'Flex designated — assign a DH from the bench.'
+            : 'DH assigned — mark a defensive player as Flex (F).'}
+        </p>
+      )}
+
+      {regularSorted.length > 0 && (
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-          <SortableContext items={sorted.map((s) => s.id)} strategy={verticalListSortingStrategy}>
+          <SortableContext items={regularSorted.map((s) => s.id)} strategy={verticalListSortingStrategy}>
             <table className="w-full text-sm">
               <thead>
                 <tr className="text-xs text-muted-foreground border-b">
+                  <th className="text-left font-medium pb-1 w-6">#</th>
                   <th className="text-left font-medium pb-1">Player</th>
                   <th className="text-left font-medium pb-1 pl-3">Pos</th>
+                  <th />
                 </tr>
               </thead>
               <tbody>
-                {sorted.map((slot, idx) => {
+                {regularSorted.map((slot, idx) => {
                   const player = players.find((p) => p.id === slot.player_id)
                   const name = player?.name ?? 'Unknown'
                   const isOutOfPosition = !!player && !player.capable_positions?.includes(slot.fielding_position)
-                  return <SortableRow key={slot.id} slot={slot} index={idx} name={name} isOutOfPosition={isOutOfPosition} />
+                  return (
+                    <SortableRow
+                      key={slot.id}
+                      slot={slot}
+                      index={idx}
+                      name={name}
+                      isOutOfPosition={isOutOfPosition}
+                      onSetFlex={onSetFlex}
+                      busy={busy}
+                    />
+                  )
                 })}
               </tbody>
             </table>
           </SortableContext>
         </DndContext>
       )}
+
+      {/* Flex row — always position 10, not draggable */}
+      {flexSlot && (
+        <div className="flex items-center gap-2 text-sm mt-1 pt-1 border-t border-muted">
+          <span className="text-xs text-muted-foreground w-6">10.</span>
+          <span>{flexPlayer?.name ?? 'Unknown'}</span>
+          <span className="text-muted-foreground pl-3 text-xs">{flexSlot.fielding_position}</span>
+          <span className="ml-1 text-xs px-1.5 py-0.5 rounded border bg-blue-100 text-blue-700 border-blue-300">F</span>
+          <button
+            aria-label="Unmark Flex"
+            disabled={busy}
+            onClick={() => onUnassignFlex?.(flexSlot.id)}
+            className="ml-auto text-xs px-1.5 py-0.5 rounded border text-muted-foreground border-muted hover:bg-muted disabled:opacity-30"
+          >
+            ×
+          </button>
+        </div>
+      )}
+
       {benchPlayers.length > 0 && (
         <div className="mt-4">
           <p className="text-xs text-muted-foreground font-medium border-b pb-1 mb-1">Bench</p>
           <ul className="text-sm space-y-1">
             {benchPlayers.map((p) => (
-              <li key={p.id} className="text-muted-foreground">
-                {p.name}
-                {p.capable_positions && p.capable_positions.length > 0 && (
-                  <span className="text-xs ml-1 opacity-60">{p.capable_positions.join(', ')}</span>
+              <li key={p.id} className="flex items-center gap-2 text-muted-foreground">
+                <span>
+                  {p.name}
+                  {p.capable_positions && p.capable_positions.length > 0 && (
+                    <span className="text-xs ml-1 opacity-60">{p.capable_positions.join(', ')}</span>
+                  )}
+                </span>
+                {!dhSlot && (
+                  <button
+                    aria-label={`Assign ${p.name} as DH`}
+                    disabled={busy}
+                    onClick={() => onAssignDH?.(p.id)}
+                    className="text-xs px-1.5 py-0.5 rounded border text-muted-foreground border-muted hover:bg-muted disabled:opacity-30 ml-auto shrink-0"
+                  >
+                    DH
+                  </button>
                 )}
               </li>
             ))}

--- a/frontend/src/components/games/LineupPrintView.tsx
+++ b/frontend/src/components/games/LineupPrintView.tsx
@@ -32,7 +32,10 @@ const hCell: React.CSSProperties = {
 const ROW_H = '20px'
 
 export default function LineupPrintView({ game, slots, players, availablePlayers }: Props) {
-  const ordered = [...slots].sort((a, b) => a.batting_order - b.batting_order)
+  const flexSlot = slots.find((s) => s.is_flex)
+  const regularSlots = [...slots]
+    .filter((s) => !s.is_flex)
+    .sort((a, b) => a.batting_order - b.batting_order)
   const assignedIds = new Set(slots.map((s) => s.player_id))
   const bench = availablePlayers.filter((p) => !assignedIds.has(p.id))
   const licensedBench = bench.filter((p) => p.license_number)
@@ -56,12 +59,12 @@ export default function LineupPrintView({ game, slots, players, availablePlayers
   const homeTeam = game.is_home ? 'Challengers' : game.opponent
   const guestTeam = game.is_home ? game.opponent : 'Challengers'
 
-  // 10 display rows: first 9 from actual slots, slot 10 reserved for Flex
+  // 10 display rows: first 9 from regular slots (including DH), row 10 = Flex player
   const displaySlots = Array.from({ length: TOTAL_BATTING_SLOTS }, (_, i) => {
-    const isFlex = i === TOTAL_BATTING_SLOTS - 1
-    const slot = isFlex ? null : (ordered[i] ?? null)
+    const isSlot10 = i === TOTAL_BATTING_SLOTS - 1
+    const slot = isSlot10 ? (flexSlot ?? null) : (regularSlots[i] ?? null)
     const player = slot ? findPlayer(slot.player_id) : null
-    return { index: i, slot, player, isFlex }
+    return { index: i, slot, player, isSlot10 }
   })
 
   // Blank rows to pad right-side bench tables so they don't look sparse
@@ -149,7 +152,10 @@ export default function LineupPrintView({ game, slots, players, availablePlayers
               </tr>
             </thead>
             <tbody>
-              {displaySlots.map(({ index, slot, player, isFlex }) => (
+              {displaySlots.map(({ index, slot, player, isSlot10 }) => {
+                const slotLabel = isSlot10 ? 'F' : `${index + 1}.`
+                const showData = slot !== null
+                return (
                 <React.Fragment key={index}>
                   {/* Row 1: player data */}
                   <tr>
@@ -160,24 +166,24 @@ export default function LineupPrintView({ game, slots, players, availablePlayers
                         textAlign: 'center',
                         fontWeight: 'bold',
                         verticalAlign: 'middle',
-                        backgroundColor: isFlex ? '#f0f0f0' : undefined,
-                        fontSize: isFlex ? '7pt' : '9pt',
+                        backgroundColor: isSlot10 ? '#f0f0f0' : undefined,
+                        fontSize: isSlot10 ? '7pt' : '9pt',
                         lineHeight: 1.1,
                       }}
                     >
-                      {isFlex ? 'Flex' : `${index + 1}.`}
+                      {slotLabel}
                     </td>
                     <td style={{ ...cell, height: ROW_H, overflow: 'hidden' }}>
-                      {!isFlex ? (player?.license_number ?? '') : ''}
+                      {showData ? (player?.license_number ?? '') : ''}
                     </td>
                     <td style={{ ...cell, height: ROW_H, textAlign: 'center', overflow: 'hidden' }}>
-                      {!isFlex ? (player?.jersey_number ?? '') : ''}
+                      {showData ? (player?.jersey_number ?? '') : ''}
                     </td>
                     <td style={{ ...cell, height: ROW_H, overflow: 'hidden' }}>
-                      {!isFlex ? (player?.name ?? '') : ''}
+                      {showData ? (player?.name ?? '') : ''}
                     </td>
                     <td style={{ ...cell, height: ROW_H, textAlign: 'center', overflow: 'hidden' }}>
-                      {!isFlex ? (slot?.fielding_position ?? '') : ''}
+                      {showData ? (slot?.fielding_position ?? '') : ''}
                     </td>
                   </tr>
                   {/* Rows 2–3: blank for substitutions */}
@@ -194,7 +200,8 @@ export default function LineupPrintView({ game, slots, players, availablePlayers
                     <td style={{ ...cell, height: ROW_H }} />
                   </tr>
                 </React.Fragment>
-              ))}
+                )
+              })}
             </tbody>
           </table>
             </td>

--- a/frontend/src/components/games/__tests__/LineupOrder.test.tsx
+++ b/frontend/src/components/games/__tests__/LineupOrder.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import LineupOrder from '../LineupOrder'
 import type { LineupSlotRead } from '@/api/lineups'
 import type { Player } from '@/api/players'
@@ -35,6 +36,7 @@ const slot1: LineupSlotRead = {
   player_id: 10,
   batting_order: 1,
   fielding_position: 'SS',
+  is_flex: false,
   created_at: '2024-01-01T00:00:00',
   updated_at: '2024-01-01T00:00:00',
 }
@@ -45,6 +47,7 @@ const slot2: LineupSlotRead = {
   player_id: 20,
   batting_order: 2,
   fielding_position: 'CF',
+  is_flex: false,
   created_at: '2024-01-01T00:00:00',
   updated_at: '2024-01-01T00:00:00',
 }
@@ -67,29 +70,28 @@ describe('LineupOrder', () => {
 
   it('renders player name and position in separate columns', () => {
     render(<LineupOrder slots={[slot1]} players={players} availablePlayers={[]} />)
-    expect(screen.getByText('1. Alice')).toBeInTheDocument()
+    expect(screen.getByText('Alice')).toBeInTheDocument()
     expect(screen.getByRole('cell', { name: 'SS' })).toBeInTheDocument()
   })
 
   it('sorts slots by batting_order regardless of array order', () => {
     render(<LineupOrder slots={[slot2, slot1]} players={players} availablePlayers={[]} />)
     const rows = within(document.querySelector('tbody')!).getAllByRole('row')
-    expect(rows[0]).toHaveTextContent('1. Alice')
+    expect(rows[0]).toHaveTextContent('Alice')
     expect(rows[0]).toHaveTextContent('SS')
-    expect(rows[1]).toHaveTextContent('2. Bob')
+    expect(rows[1]).toHaveTextContent('Bob')
     expect(rows[1]).toHaveTextContent('CF')
   })
 
   it('shows "Unknown" for player not in players array', () => {
     const orphanSlot: LineupSlotRead = { ...slot1, id: 99, player_id: 999 }
     render(<LineupOrder slots={[orphanSlot]} players={players} availablePlayers={[]} />)
-    expect(screen.getByText('1. Unknown')).toBeInTheDocument()
+    expect(screen.getByText('Unknown')).toBeInTheDocument()
   })
 
   it('resolves name from players array', () => {
     render(<LineupOrder slots={[slot2]} players={players} availablePlayers={[]} />)
-    // Only one slot rendered, so it always shows position 1 regardless of stored batting_order
-    expect(screen.getByText('1. Bob')).toBeInTheDocument()
+    expect(screen.getByText('Bob')).toBeInTheDocument()
     expect(screen.getByRole('cell', { name: 'CF' })).toBeInTheDocument()
   })
 
@@ -121,6 +123,85 @@ describe('LineupOrder', () => {
       const cell = screen.getByRole('cell', { name: 'SS' })
       expect(cell).toHaveClass('text-muted-foreground')
       expect(cell).not.toHaveClass('text-amber-600')
+    })
+  })
+
+  describe('DH / Flex', () => {
+    const flexSlot: LineupSlotRead = { ...slot1, id: 3, is_flex: true, batting_order: 2 }
+    const dhSlot: LineupSlotRead = { ...slot2, id: 4, fielding_position: 'DH', batting_order: 1 }
+
+    it('shows Flex player at position 10 below the batting order table', () => {
+      render(<LineupOrder slots={[slot2, flexSlot]} players={players} availablePlayers={[]} />)
+      expect(screen.getByText('10.')).toBeInTheDocument()
+      expect(screen.getAllByText('Alice').length).toBeGreaterThan(0)
+    })
+
+    it('Flex player does not appear as a numbered row in the batting table', () => {
+      render(<LineupOrder slots={[flexSlot]} players={players} availablePlayers={[]} />)
+      // The flex row appears outside the table (no numbered batting slot)
+      expect(screen.queryByRole('row', { name: /Alice/ })).not.toBeInTheDocument()
+      expect(screen.getByText('Alice')).toBeInTheDocument()
+    })
+
+    it('DH player appears in the regular batting order table', () => {
+      render(<LineupOrder slots={[dhSlot]} players={players} availablePlayers={[]} />)
+      const tbody = document.querySelector('tbody')!
+      expect(within(tbody).getByText('Bob')).toBeInTheDocument()
+      expect(within(tbody).getByText('DH')).toBeInTheDocument()
+    })
+
+    it('shows F badge on the Flex row', () => {
+      render(<LineupOrder slots={[slot2, flexSlot]} players={players} availablePlayers={[]} />)
+      // "F" badge appears in the flex row section (not the button)
+      const flexBadges = screen.getAllByText('F')
+      expect(flexBadges.length).toBeGreaterThan(0)
+    })
+
+    it('shows DH warning when flex set but no DH', () => {
+      render(<LineupOrder slots={[flexSlot]} players={players} availablePlayers={[]} />)
+      expect(screen.getByText(/assign a dh from the bench/i)).toBeInTheDocument()
+    })
+
+    it('shows Flex warning when DH set but no flex', () => {
+      render(<LineupOrder slots={[dhSlot]} players={players} availablePlayers={[]} />)
+      expect(screen.getByText(/mark a defensive player as flex/i)).toBeInTheDocument()
+    })
+
+    it('shows no warning when neither DH nor Flex is set', () => {
+      render(<LineupOrder slots={[slot1]} players={players} availablePlayers={[]} />)
+      expect(screen.queryByText(/assign a dh/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/mark a defensive/i)).not.toBeInTheDocument()
+    })
+
+    it('shows DH button on bench players when no DH assigned', () => {
+      render(<LineupOrder slots={[slot1]} players={players} availablePlayers={players} />)
+      expect(screen.getByRole('button', { name: /assign bob as dh/i })).toBeInTheDocument()
+    })
+
+    it('hides DH button on bench when DH already assigned', () => {
+      render(<LineupOrder slots={[slot1, dhSlot]} players={players} availablePlayers={players} />)
+      expect(screen.queryByRole('button', { name: /assign.*dh/i })).not.toBeInTheDocument()
+    })
+
+    it('calls onAssignDH with player id when DH button clicked', async () => {
+      const onAssignDH = vi.fn()
+      render(<LineupOrder slots={[slot1]} players={players} availablePlayers={players} onAssignDH={onAssignDH} />)
+      await userEvent.click(screen.getByRole('button', { name: /assign bob as dh/i }))
+      expect(onAssignDH).toHaveBeenCalledWith(20)
+    })
+
+    it('calls onSetFlex when F button clicked on a row', async () => {
+      const onSetFlex = vi.fn()
+      render(<LineupOrder slots={[slot1]} players={players} availablePlayers={[]} onSetFlex={onSetFlex} />)
+      await userEvent.click(screen.getByRole('button', { name: /mark as flex/i }))
+      expect(onSetFlex).toHaveBeenCalledWith(1, true)
+    })
+
+    it('calls onUnassignFlex when × clicked on the Flex row', async () => {
+      const onUnassignFlex = vi.fn()
+      render(<LineupOrder slots={[flexSlot]} players={players} availablePlayers={[]} onUnassignFlex={onUnassignFlex} />)
+      await userEvent.click(screen.getByRole('button', { name: /unmark flex/i }))
+      expect(onUnassignFlex).toHaveBeenCalledWith(3)
     })
   })
 
@@ -164,9 +245,8 @@ describe('LineupOrder', () => {
       const noPosBob: Player = { ...players[1], capable_positions: null }
       render(<LineupOrder slots={[slot1]} players={[players[0], noPosBob]} availablePlayers={[players[0], noPosBob]} />)
       const bench = screen.getByText('Bench').closest('div')!
-      // Bob row should not contain any position abbreviation span
-      const bobItem = within(bench).getByText('Bob')
-      expect(bobItem.nextSibling).toBeNull()
+      // Bob has no positions — no position abbreviation should appear next to his name
+      expect(within(bench).queryByText('CF')).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/components/games/__tests__/LineupPrintView.test.tsx
+++ b/frontend/src/components/games/__tests__/LineupPrintView.test.tsx
@@ -48,6 +48,7 @@ const slot1: LineupSlotRead = {
   player_id: 10,
   batting_order: 1,
   fielding_position: 'SS',
+  is_flex: false,
   created_at: '2024-01-01T00:00:00',
   updated_at: '2024-01-01T00:00:00',
 }
@@ -70,11 +71,11 @@ describe('LineupPrintView', () => {
     expect(screen.getByText('Jun 12, 2026')).toBeInTheDocument()
   })
 
-  it('renders 10 batting order slots including Flex', () => {
+  it('renders 10 batting order slots with F label at slot 10', () => {
     render(<LineupPrintView game={awayGame} slots={[]} players={[]} availablePlayers={[]} />)
     expect(screen.getByText('1.')).toBeInTheDocument()
     expect(screen.getByText('9.')).toBeInTheDocument()
-    expect(screen.getByText('Flex')).toBeInTheDocument()
+    expect(screen.getByText('F')).toBeInTheDocument()
   })
 
   it('shows player name, license, jersey number and position in their batting slot', () => {

--- a/frontend/src/pages/GameDetailPage.tsx
+++ b/frontend/src/pages/GameDetailPage.tsx
@@ -21,6 +21,7 @@ import {
   createLineup,
   getLineup,
   createSlot,
+  updateSlot,
   deleteSlot,
   reorderSlots,
   type LineupReadWithSlots,
@@ -145,6 +146,30 @@ export default function GameDetailPage() {
     } finally {
       setBusy(false)
     }
+  }
+
+  async function handleSetFlex(slotId: number, isFlex: boolean) {
+    if (!lineup) return
+    setBusy(true)
+    setMutationError(null)
+    try {
+      if (isFlex) {
+        const currentFlex = lineup.slots.find((s) => s.is_flex && s.id !== slotId)
+        if (currentFlex) {
+          await updateSlot(lineup.id, currentFlex.id, { is_flex: false })
+        }
+      }
+      await updateSlot(lineup.id, slotId, { is_flex: isFlex })
+      setLineup(await getLineup(lineup.id))
+    } catch (err) {
+      setMutationError(err instanceof Error ? err.message : 'Failed to update flex')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function handleAssignDH(playerId: number) {
+    await handleAssign(playerId, 'DH')
   }
 
   async function handleReorder(orderedSlotIds: number[]) {
@@ -274,6 +299,10 @@ export default function GameDetailPage() {
             players={players}
             availablePlayers={availablePlayers}
             onReorder={(ids) => void handleReorder(ids)}
+            onSetFlex={(slotId, isFlex) => void handleSetFlex(slotId, isFlex)}
+            onAssignDH={(playerId) => void handleAssignDH(playerId)}
+            onUnassignFlex={(slotId) => void handleSetFlex(slotId, false)}
+            busy={busy}
           />
         </div>
       </div>

--- a/frontend/src/pages/__tests__/GameDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/GameDetailPage.test.tsx
@@ -109,6 +109,7 @@ beforeEach(() => {
     player_id: 10,
     batting_order: 1,
     fielding_position: 'SS',
+    is_flex: false,
     created_at: '2024-01-01T00:00:00',
     updated_at: '2024-01-01T00:00:00',
   })
@@ -120,6 +121,7 @@ beforeEach(() => {
     player_id: 10,
     batting_order: 1,
     fielding_position: 'SS',
+    is_flex: false,
     created_at: '2024-01-01T00:00:00',
     updated_at: '2024-01-01T00:00:00',
   })
@@ -267,6 +269,7 @@ describe('GameDetailPage', () => {
       player_id: 10,
       batting_order: 2,
       fielding_position: 'SS',
+      is_flex: false,
       created_at: '2024-01-01T00:00:00',
       updated_at: '2024-01-01T00:00:00',
     }
@@ -324,7 +327,7 @@ describe('GameDetailPage', () => {
     // resolve to clean up
     resolveSlot({
       id: 1, lineup_id: 100, player_id: 10, batting_order: 1,
-      fielding_position: 'SS', created_at: '', updated_at: '',
+      fielding_position: 'SS', is_flex: false, created_at: '', updated_at: '',
     })
   })
 })

--- a/frontend/src/pages/__tests__/GamesPage.test.tsx
+++ b/frontend/src/pages/__tests__/GamesPage.test.tsx
@@ -58,7 +58,7 @@ beforeEach(() => {
   vi.mocked(getLineups).mockResolvedValue([])
   vi.mocked(getLineup).mockResolvedValue({ id: 1, game_id: 1, name: 'Default', is_final: false, created_at: '', updated_at: '', slots: [] })
   vi.mocked(createLineup).mockResolvedValue({ id: 1, game_id: 99, name: 'Default', is_final: false, created_at: '', updated_at: '' })
-  vi.mocked(createSlot).mockResolvedValue({ id: 1, lineup_id: 1, player_id: 1, batting_order: 1, fielding_position: 'SS', created_at: '', updated_at: '' })
+  vi.mocked(createSlot).mockResolvedValue({ id: 1, lineup_id: 1, player_id: 1, batting_order: 1, fielding_position: 'SS', is_flex: false, created_at: '', updated_at: '' })
 })
 
 describe('GamesPage', () => {
@@ -212,7 +212,7 @@ describe('GamesPage', () => {
     vi.mocked(createGame).mockResolvedValue(newGame)
     vi.mocked(getLineups).mockResolvedValue([{ id: 10, game_id: game1.id, name: 'Default', is_final: false, created_at: '', updated_at: '' }])
     vi.mocked(getLineup).mockResolvedValue({ id: 10, game_id: game1.id, name: 'Default', is_final: false, created_at: '', updated_at: '',
-      slots: [{ id: 1, lineup_id: 10, player_id: 7, batting_order: 1, fielding_position: 'SS', created_at: '', updated_at: '' }],
+      slots: [{ id: 1, lineup_id: 10, player_id: 7, batting_order: 1, fielding_position: 'SS', is_flex: false, created_at: '', updated_at: '' }],
     })
     vi.mocked(createLineup).mockResolvedValue(newLineup)
     render(<MemoryRouter><GamesPage /></MemoryRouter>)


### PR DESCRIPTION
## Summary

Adds DH (Designated Hitter) and Flex (F) support to the lineup builder. Using DH/Flex is optional — a regular 9-player lineup works exactly as before.

**How it works:**
- **DH**: click the **DH** button next to a bench player to assign them as the designated hitter. They appear in the regular batting order (positions 1–9) and can be dragged to any slot.
- **Flex (F)**: click the **F** button on any defensive player's row to designate them as the Flex. They are shown at position 10 (below the batting order) with an F badge — they play defense but do not bat.
- If only one of DH/Flex is set, a warning prompts the coach to complete the pair.
- On the **print sheet**, slot 10 shows the Flex player with the "F" label and their real fielding position.

## Changes

- `is_flex` boolean added to `LineupSlot` (backend model, schema, migration)
- `LineupOrder`: F toggle button on each batting row, DH button on bench players, Flex row pinned at position 10
- `LineupPrintView`: slot 10 shows Flex player with "F" label
- `GameDetailPage`: `handleSetFlex` and `handleAssignDH` handlers wired up

## Test plan

- [ ] Assign a bench player as DH — they appear in the batting order, can be dragged
- [ ] Mark a defensive player as Flex — they move to position 10 with F badge
- [ ] Verify warning appears with only one of DH/Flex set
- [ ] Print — confirm slot 10 shows the Flex player's name and position
- [ ] Unmark Flex (× button) — player returns to normal batting order slot
- [ ] Regular 9-player lineup with no DH/Flex works unchanged
- [ ] All CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)